### PR TITLE
[#57] api 분리

### DIFF
--- a/src/api/card.ts
+++ b/src/api/card.ts
@@ -1,0 +1,26 @@
+import { instance } from '@/libs/api';
+
+export async function getCards() {
+  const response = await instance.get('/cards');
+  return response.data;
+}
+
+export async function getDetailCard(cardId: string) {
+  const response = await instance.get(`/cards/${cardId}`);
+  return response.data;
+}
+
+export async function postCard() {
+  const response = await instance.post('/cards');
+  return response.data;
+}
+
+export async function putCard(cardId: string) {
+  const response = await instance.put(`/cards/${cardId}`);
+  return response.data;
+}
+
+export async function deleteCard(cardId: string) {
+  const response = await instance.delete(`/cards/${cardId}`);
+  return response.data;
+}

--- a/src/api/column.ts
+++ b/src/api/column.ts
@@ -1,0 +1,10 @@
+import { instanceFiles } from '@/libs/api';
+
+export async function postColumnImage(body: FormData, columnId: string) {
+  const response = await instanceFiles.post(
+    `/columns/${columnId}/card-image`,
+    body,
+  );
+
+  return response.data;
+}

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -1,0 +1,6 @@
+import { instance } from '@/libs/api';
+
+export async function getComments() {
+  const response = await instance.get('/comments');
+  return response.data;
+}

--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -1,0 +1,6 @@
+import { instance } from '@/libs/api';
+
+export async function getDashboards() {
+  const response = await instance.get('/dashboards');
+  return response.data;
+}

--- a/src/api/invitations.ts
+++ b/src/api/invitations.ts
@@ -1,0 +1,6 @@
+import { instance } from '@/libs/api';
+
+export async function getInvitations() {
+  const response = await instance.get('/invitations');
+  return response.data;
+}

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,0 +1,11 @@
+import { instance } from '@/libs/api';
+
+export async function getMembers() {
+  const response = await instance.get('/members');
+  return response.data;
+}
+
+export async function deleteMember(memberId: string) {
+  const response = await instance.delete(`/members/${memberId}`);
+  return response.data;
+}

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = 'https://sp-taskify-api.vercel.app/2-5/' as const;
+export const BASE_URL = 'https://sp-taskify-api.vercel.app/1-5/' as const;

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -1,8 +1,19 @@
-import axios, { AxiosError, AxiosResponse } from 'axios';
 import { BASE_URL } from '@/constants/common';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 
 export const instance = axios.create({
   baseURL: BASE_URL,
+  headers: {
+    'Content-type': 'application/json',
+  },
+});
+
+export const instanceFiles = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'multipart/form-data',
+  },
+  withCredentials: true,
 });
 
 instance.interceptors.request.use(


### PR DESCRIPTION
## 📖 작업 내용

- [x] api에 맞게 분리합니다

## ✅ PR 포인트

columns의 이미지 업로드 등 multipart/form-data인 경우가 있어 따로 정의했어요

api별로 폴더로 관리하면 좋을 것 같아 다음과 같이 분리했어요

api 사람마다 다르게 짤 것 같아 통일성을 위해 일부분 작성했는데 어떠신가요 ??
(get api일 경우 get~, post일 경우 post~)

타입은 사용하시는 분이 따로 정의해주세용

api 경로가 {기수}-{팀} 이어서 1-5로 수정했습니당

## 📸 스크린샷