### PR TITLE
[#108] 대시보드 삭제 기능, 삭제 후 페이지 라우팅 구현

### DIFF
--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -95,3 +95,22 @@ export async function putDashboard(
     }
   }
 }
+
+export async function deleteDashboard(dashboardId: string) {
+  const option = {
+    endpoint: `/dashboards/${dashboardId}`,
+    method: 'DELETE',
+  };
+  try {
+    const response = await axios.post('/api/withAuthHandler', option);
+    if (response.status === 204) {
+      alert('대시보드 삭제가 완료되었습니다.');
+      return true;
+    }
+  } catch (e: unknown) {
+    if (e instanceof AxiosError) {
+      alert(e);
+      return false;
+    }
+  }
+}

--- a/src/components/button/dashBoard/delete/deleteDashBoardButton.tsx
+++ b/src/components/button/dashBoard/delete/deleteDashBoardButton.tsx
@@ -1,7 +1,26 @@
+import { deleteDashboard } from '@/api/dashboard';
 import S from '@/components/button/dashBoard/delete/deleteDashBoard.module.css';
+import { useRouter } from 'next/router';
 
-function DeleteDashBoardButton() {
-  return <button className={S.container}>대시보드 삭제하기</button>;
+interface DeleteDashboardProps {
+  dashboardId: string;
+}
+
+function DeleteDashBoardButton({ dashboardId }: DeleteDashboardProps) {
+  const router = useRouter();
+
+  async function handleDeleteClick() {
+    const result = await deleteDashboard(dashboardId);
+    if (result) {
+      router.push('/mydashboard');
+    }
+  }
+
+  return (
+    <button className={S.container} onClick={handleDeleteClick}>
+      대시보드 삭제하기
+    </button>
+  );
 }
 
 export default DeleteDashBoardButton;

--- a/src/pages/[id]/mydashboard.tsx
+++ b/src/pages/[id]/mydashboard.tsx
@@ -80,7 +80,7 @@ function DashboardEditPage({ dashboardId }: DashboardEditPageProps) {
               setIsModalOpen={setIsModalOpen}
             />
             <div className={S.marginDiv}></div>
-            <DeleteDashBoardButton />
+            <DeleteDashBoardButton dashboardId={dashboardId} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 📖 작업 내용

- [x] 대시보드 삭제 기능 구현
- [x] 대시보드 삭제 후 페이지 라우팅 구현



## ✅ PR 포인트
### 피그마 시안, 노션에 대시보드 삭제에 대한 요구사항이 없었고 삭제 후 경로를 어디로 설정할 지에 대한 것도 없었습니다. 고민해본 결과 대시보드가 삭제된 후 /mydashboard로 페이지를 전환하는 것이 가장 적합하다고 생각하였습니다.

## 📸 스크린샷

https://github.com/Team-Plants/PLANTS/assets/127609484/f4ebc494-2d11-42de-9f8d-81c331ec6581

