### PR TITLE
[#152] fix : 'dashboard/[id]/edit' pagination error 수정

### DIFF
--- a/src/components/table/member/memberItem.module.css
+++ b/src/components/table/member/memberItem.module.css
@@ -21,14 +21,41 @@
 .infoGroup {
   font-size: 1.4rem;
   gap: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
   @media all and (tablet) {
     gap: 12px;
     font-size: 1.6rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   @media all and (desktop) {
     gap: 12px;
     font-size: 1.6rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
+
+.profileImage {
+  border-radius: 50%;
+  margin: 13px 12px 13px 0px;
+  width: 34px;
+  height: 34px;
+
+  @media all and (tablet) {
+    margin: 13px 12px;
+    width: 38px;
+    height: 38px;
+  }
+  @media all and (desktop) {
+    margin: 13px 12px;
+    width: 38px;
+    height: 38px;
   }
 }

--- a/src/components/table/member/memberItem.tsx
+++ b/src/components/table/member/memberItem.tsx
@@ -1,10 +1,11 @@
 import { DeleteMember } from '@/api/member';
 import Button from '@/components/button/button';
 import S from '@/components/table/member/memberItem.module.css';
-import QUERY_KEYS from '@/constants/queryKeys';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import CrownImg from '@/assets/icons/Crown.svg';
 import Image from 'next/image';
+import NameBadge from '@/components/nameBadge/nameBadge';
+import { randomNickNameColor } from '@/utils/utility';
 
 interface MemberItemProps {
   nickname: string;
@@ -18,32 +19,40 @@ function MemberItem({
   nickname,
   profileImageUrl,
   memberId,
-  setMemberFlag,
   isOwner,
 }: MemberItemProps) {
-  const { isLoading, data, refetch } = useQuery({
-    queryKey: [QUERY_KEYS.deleteMember],
-    queryFn: () => DeleteMember(String(memberId)),
-    enabled: false,
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: () => DeleteMember(String(memberId)),
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+    },
   });
-
-  async function fetchDeleteMember() {
-    if (isLoading) return;
-    await refetch();
-  }
 
   async function handleCancelClick() {
     try {
-      await fetchDeleteMember();
-      setMemberFlag(true);
+      mutation.mutate();
     } catch (error) {
       console.error(error);
     }
   }
   return (
     <div className={S.container}>
-      {/* TODO: 아바타 배지 넣기 */}
       <div className={S.infoGroup}>
+        {profileImageUrl ? (
+          <Image
+            src={profileImageUrl}
+            alt="프로필"
+            width={38}
+            height={38}
+            className={S.profileImage}
+          />
+        ) : (
+          <NameBadge
+            letter={nickname.slice(0, 1)}
+            color={randomNickNameColor()}
+          />
+        )}
         {`${nickname} `}
         {isOwner && (
           <Image src={CrownImg} alt="왕관 이미지" width={17.6} height={14} />

--- a/src/components/table/member/memberList.tsx
+++ b/src/components/table/member/memberList.tsx
@@ -4,7 +4,7 @@ import { MemberProps } from '@/types/Member';
 import { useQuery } from '@tanstack/react-query';
 import QUERY_KEYS from '@/constants/queryKeys';
 import { getPaginationMembers } from '@/api/member';
-import { useEffect, useState } from 'react';
+import { Key, useEffect, useState } from 'react';
 import PaginationArrowButton from '@/components/button/arrow/paginationArrowButton';
 
 interface MemberListProps {
@@ -22,24 +22,15 @@ function MemberList({
   const [totalPage, setTotalPage] = useState<number>(0);
   const [totalCount, setTotalCount] = useState();
   const { isLoading, data, refetch } = useQuery({
-    queryKey: [QUERY_KEYS.members],
+    queryKey: [QUERY_KEYS.members, page, Number(dashboardId)],
     queryFn: () => getPaginationMembers(page, 4, Number(dashboardId)),
     enabled: true,
   });
 
-  async function fetchMoreMembers() {
-    if (isLoading) return;
-    await refetch();
-  }
-
-  useEffect(() => {
-    fetchMoreMembers();
-  }, [page]);
-
   useEffect(() => {
     setTotalCount(data?.totalCount);
-    fetchMoreMembers();
-  }, [data, dashboardId]);
+    refetch();
+  }, [data]);
 
   useEffect(() => {
     if (totalCount === undefined) return;
@@ -49,13 +40,6 @@ function MemberList({
       setTotalPage(Math.ceil(totalCount / 4));
     }
   }, [totalCount]);
-
-  useEffect(() => {
-    if (memberFlag) {
-      fetchMoreMembers();
-      setMemberFlag(false);
-    }
-  }, [memberFlag]);
 
   useEffect(() => {
     if (totalPage !== 0 && totalPage < page) setPage((prev) => prev - 1);
@@ -78,9 +62,9 @@ function MemberList({
       <div className={S.label}>이름</div>
       <div>
         {data &&
-          data?.members.map((member: MemberProps) => {
+          data?.members.map((member: MemberProps, index: Key) => {
             return (
-              <div className={S.tableItem} key={member.userId}>
+              <div className={S.tableItem} key={index}>
                 <MemberItem
                   isOwner={member.isOwner}
                   nickname={member.nickname}

--- a/src/pages/dashboard/[id]/edit/index.tsx
+++ b/src/pages/dashboard/[id]/edit/index.tsx
@@ -7,13 +7,13 @@ import EditDashboard from '@/components/table/editDashboard/editDashboard';
 import InvitationList from '@/components/table/invitation/invitationList';
 import MemberList from '@/components/table/member/memberList';
 import QUERY_KEYS from '@/constants/queryKeys';
-import { instance } from '@/libs/api';
 import S from '@/pages/dashboard/[id]/edit/dashboardEditPage.module.css';
 import { MemberProps } from '@/types/Member';
 import { useQuery } from '@tanstack/react-query';
-import { AxiosResponse } from 'axios';
 import { GetServerSidePropsContext } from 'next';
 import { useEffect, useState } from 'react';
+import { instance } from '@/libs/api';
+import { AxiosResponse } from 'axios';
 
 interface Dashboard {
   id: number;
@@ -60,7 +60,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       };
     }
   } catch (error) {
-    console.log(error);
+    alert(error);
   }
 
   return {

--- a/src/pages/dashboard/[id]/edit/index.tsx
+++ b/src/pages/dashboard/[id]/edit/index.tsx
@@ -60,7 +60,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       };
     }
   } catch (error) {
-    alert(error);
+    console.log(error);
   }
 
   return {


### PR DESCRIPTION
## 📖 작업 내용
- 페이지네이션 오류 수정합니다.
- 구성원 삭제시 바로 반영됩니다.
- todo 로 되어있던 프로필 이미지 or 이름 뱃지 넣었습니다.

## ✅ PR 포인트
- 이쁘게 잘 넘어갔다가 돌아옵니다.
- 이름이 반짝반짝 해지네요,,,

## 📸 스크린샷
#### 수정 전
![ezgif com-video-to-gif-converter (3)](https://github.com/Team-Plants/PLANTS/assets/138510303/36eb8d2e-35dd-4950-8a7a-92282513fea6)

#### 수정 후

- 페이지네이션
![ezgif com-video-to-gif-converter (4)](https://github.com/Team-Plants/PLANTS/assets/138510303/b5625bb6-26c2-4a26-9226-66b0ff3185ea)

- 삭제 & 뱃지 추가
![ezgif com-video-to-gif-converter (5)](https://github.com/Team-Plants/PLANTS/assets/138510303/6d53d90b-6ad7-4525-8482-00b5913a0dfa)

