### PR TITLE
[#167] 사이드메뉴 각 대시보드 마우스 호버했을 때 색 변경

### DIFF
--- a/src/components/sideMenu/SideMenu.tsx
+++ b/src/components/sideMenu/SideMenu.tsx
@@ -12,6 +12,7 @@ import NewDashboardModal from '@/components/modal/newDashboardModal/newDashboard
 import { getDashboards, getSideMenuDashboards } from '@/api/dashboard';
 import { useQuery } from '@tanstack/react-query';
 import QUERY_KEYS from '@/constants/queryKeys';
+import SideMenuItem from './sideMenuItem';
 
 interface SideMenuProps {
   pageId: number;
@@ -127,29 +128,14 @@ function SideMenu({ pageId, initialPage, flag, refreshFlag }: SideMenuProps) {
         <ul className={S.dashBoardContainer}>
           {dashboards &&
             dashboards.map((dashboard) => (
-              <Link href={`/dashboard/${dashboard.id}`} key={dashboard.id}>
-                <li
-                  className={S.dashBoardLi}
-                  style={{
-                    backgroundColor:
-                      pageId == dashboard.id ? '#F1EFFD' : '#FFF',
-                  }}>
-                  <div
-                    className={S.dashBoardColor}
-                    style={{ backgroundColor: `${dashboard.color}` }}></div>
-                  <div className={S.dashBoardTitle}>
-                    {dashboard.title + ' '}
-                    {dashboard.createdByMe && (
-                      <Image
-                        src={CrownImg}
-                        alt="왕관 이미지"
-                        width={17.6}
-                        height={14}
-                      />
-                    )}
-                  </div>
-                </li>
-              </Link>
+              <SideMenuItem
+                dashboardId={dashboard.id}
+                pageId={pageId}
+                dashboardColor={dashboard.color}
+                dashboardTitle={dashboard.title}
+                createdByMe={dashboard.createdByMe}
+                key={dashboard.id}
+              />
             ))}
           <div ref={setTarget} className={S.refContainer}>
             <div className={S.loading}>{isLoading && 'loading...'}</div>

--- a/src/components/sideMenu/SideMenu.tsx
+++ b/src/components/sideMenu/SideMenu.tsx
@@ -8,10 +8,10 @@ import { MouseEvent, useEffect, useState } from 'react';
 import { DashBoardList } from '@/types/DashBoard';
 import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 import NewDashboardModal from '@/components/modal/newDashboardModal/newDashboardModal';
-import { getDashboards, getSideMenuDashboards } from '@/api/dashboard';
+import { getDashboards } from '@/api/dashboard';
 import { useQuery } from '@tanstack/react-query';
 import QUERY_KEYS from '@/constants/queryKeys';
-import SideMenuItem from './sideMenuItem';
+import SideMenuItem from '@/components/sideMenu/sideMenuItem';
 
 interface SideMenuProps {
   pageId: number;

--- a/src/components/sideMenu/SideMenu.tsx
+++ b/src/components/sideMenu/SideMenu.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import SmallLogoImg from '@/assets/icons/SmallLogo.svg';
 import TaskifyImg from '@/assets/icons/Taskify.svg';
 import AddBoxImg from '@/assets/icons/AddBox.svg';
-import CrownImg from '@/assets/icons/Crown.svg';
 import { MouseEvent, useEffect, useState } from 'react';
 import { DashBoardList } from '@/types/DashBoard';
 import useIntersectionObserver from '@/hooks/useIntersectionObserver';

--- a/src/components/sideMenu/sideMenu.module.css
+++ b/src/components/sideMenu/sideMenu.module.css
@@ -129,53 +129,6 @@
   }
 }
 
-.dashBoardLi {
-  width: 40px;
-  list-style: none;
-  display: flex;
-  gap: 16px;
-  padding: 0 12px;
-  height: 40px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 4px;
-
-  @media (tablet) {
-    width: auto;
-    justify-content: left;
-    height: 43px;
-  }
-  @media (desktop) {
-    height: 45px;
-    width: auto;
-    justify-content: left;
-  }
-}
-
-.dashBoardColor {
-  width: 8px;
-  height: 8px;
-  border-radius: 50px;
-  background: var(--gray-50);
-}
-
-.dashBoardTitle {
-  color: var(--gray-50);
-  font-size: 1.6rem;
-  font-style: normal;
-  font-weight: 500;
-  line-height: normal;
-  display: none;
-
-  @media (tablet) {
-    display: block;
-  }
-
-  @media (desktop) {
-    display: block;
-  }
-}
-
 .refContainer {
   width: 69px;
   height: auto;

--- a/src/components/sideMenu/sideMenuItem.module.css
+++ b/src/components/sideMenu/sideMenuItem.module.css
@@ -44,9 +44,11 @@
 
   @media (tablet) {
     display: block;
+    width: 90px;
   }
 
   @media (desktop) {
     display: block;
+    width: 220px;
   }
 }

--- a/src/components/sideMenu/sideMenuItem.module.css
+++ b/src/components/sideMenu/sideMenuItem.module.css
@@ -1,0 +1,48 @@
+@value tablet, desktop from "@/styles/breakpoints.css";
+
+.dashBoardLi {
+  width: 40px;
+  list-style: none;
+  display: flex;
+  gap: 16px;
+  padding: 0 12px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+
+  @media (tablet) {
+    width: auto;
+    justify-content: left;
+    height: 43px;
+  }
+  @media (desktop) {
+    height: 45px;
+    width: auto;
+    justify-content: left;
+  }
+}
+
+.dashBoardColor {
+  width: 8px;
+  height: 8px;
+  border-radius: 50px;
+  background: var(--gray-50);
+}
+
+.dashBoardTitle {
+  color: var(--gray-50);
+  font-size: 1.6rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  display: none;
+
+  @media (tablet) {
+    display: block;
+  }
+
+  @media (desktop) {
+    display: block;
+  }
+}

--- a/src/components/sideMenu/sideMenuItem.module.css
+++ b/src/components/sideMenu/sideMenuItem.module.css
@@ -23,6 +23,10 @@
   }
 }
 
+.dashBoardLi:hover {
+  background-color: #f1effd !important;
+}
+
 .dashBoardColor {
   width: 8px;
   height: 8px;

--- a/src/components/sideMenu/sideMenuItem.tsx
+++ b/src/components/sideMenu/sideMenuItem.tsx
@@ -9,7 +9,6 @@ interface SideMenuItemProps {
   dashboardColor: string;
   dashboardTitle: string;
   createdByMe: boolean;
-  key: number;
 }
 
 function SideMenuItem({
@@ -18,10 +17,9 @@ function SideMenuItem({
   dashboardColor,
   dashboardTitle,
   createdByMe,
-  key,
 }: SideMenuItemProps) {
   return (
-    <Link href={`/dashboard/${dashboardId}`} key={key}>
+    <Link href={`/dashboard/${dashboardId}`} key={dashboardId}>
       <li
         className={S.dashBoardLi}
         style={{

--- a/src/components/sideMenu/sideMenuItem.tsx
+++ b/src/components/sideMenu/sideMenuItem.tsx
@@ -1,0 +1,44 @@
+import S from '@/components/sideMenu/sideMenuItem.module.css';
+import Link from 'next/link';
+import Image from 'next/image';
+import CrownImg from '@/assets/icons/Crown.svg';
+
+interface SideMenuItemProps {
+  dashboardId: number;
+  pageId: number;
+  dashboardColor: string;
+  dashboardTitle: string;
+  createdByMe: boolean;
+  key: number;
+}
+
+function SideMenuItem({
+  dashboardId,
+  pageId,
+  dashboardColor,
+  dashboardTitle,
+  createdByMe,
+  key,
+}: SideMenuItemProps) {
+  return (
+    <Link href={`/dashboard/${dashboardId}`} key={key}>
+      <li
+        className={S.dashBoardLi}
+        style={{
+          backgroundColor: pageId == dashboardId ? '#F1EFFD' : '#FFF',
+        }}>
+        <div
+          className={S.dashBoardColor}
+          style={{ backgroundColor: `${dashboardColor}` }}></div>
+        <div className={S.dashBoardTitle}>
+          {dashboardTitle + ' '}
+          {createdByMe && (
+            <Image src={CrownImg} alt="왕관 이미지" width={17.6} height={14} />
+          )}
+        </div>
+      </li>
+    </Link>
+  );
+}
+
+export default SideMenuItem;


### PR DESCRIPTION
## 📖 작업 내용

- [x] 사이드메뉴의 개별 대시보드를 컴포넌트로 분리
- [x] 대시보드 색상 영역 찌그러짐 현상 수정
- [x] 사이드메뉴 각 대시보드 마우스 호버했을 때 색 변경


## 📸 스크린샷

https://github.com/Team-Plants/PLANTS/assets/127609484/caa875d3-8aed-4170-9280-1a536a2bc8a7

