### PR TITLE
[#189] feat: 대시보드 수정 페이지에서 헤더 내부의 관리 버튼 제거

### DIFF
--- a/src/components/header/dashboardHeader/dashboardHeader.tsx
+++ b/src/components/header/dashboardHeader/dashboardHeader.tsx
@@ -24,6 +24,7 @@ interface DashboardProps {
   Owner?: boolean;
   active?: boolean;
   id?: string;
+  isEditButtonActive?: boolean;
 }
 
 function DashboardHeader({
@@ -33,6 +34,7 @@ function DashboardHeader({
   Owner = false,
   active = true,
   id,
+  isEditButtonActive = false,
 }: DashboardProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -54,18 +56,20 @@ function DashboardHeader({
       <div className={S.buttonContainer}>
         {Owner && active && (
           <>
-            <Link href={`/dashboard${id ? `/${id}` : ''}/edit`}>
-              <button className={S.button}>
-                <Image
-                  className={S.buttonImg}
-                  src={SettingImg}
-                  width={20}
-                  height={20}
-                  alt="관리하기"
-                />
-                관리
-              </button>
-            </Link>
+            {isEditButtonActive && (
+              <Link href={`/dashboard${id ? `/${id}` : ''}/edit`}>
+                <button className={S.button}>
+                  <Image
+                    className={S.buttonImg}
+                    src={SettingImg}
+                    width={20}
+                    height={20}
+                    alt="관리하기"
+                  />
+                  관리
+                </button>
+              </Link>
+            )}
             <button className={S.button} onClick={handleClick}>
               <Image
                 className={S.buttonImg}

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -21,6 +21,7 @@ export interface LayoutProps {
   member?: MemberProps[];
   secondAddFlag?: boolean;
   setSecondAddFlag?: React.Dispatch<SetStateAction<boolean>>;
+  isEditButtonActive?: boolean;
 }
 
 function Layout({
@@ -34,6 +35,7 @@ function Layout({
   member,
   secondAddFlag,
   setSecondAddFlag,
+  isEditButtonActive,
 }: LayoutProps) {
   const mounted = useRef(false);
   const [refreshFlag, setRefreshFlag] = useState(false);
@@ -84,6 +86,7 @@ function Layout({
               Owner={Owner}
               active={active}
               id={id}
+              isEditButtonActive={isEditButtonActive}
             />
           </div>
           <div className={S.childrenContainer}>{children}</div>

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -87,6 +87,7 @@ function dashboard({ dashboardId }: { dashboardId: string }) {
   const [fullData, setFullData] = useState([]);
   const [folderName, setFolderName] = useState();
   const [folderOwner, setFolderOwner] = useState();
+  const isEditButtonActive = true;
   const { data: myDashboard } = useQuery({
     queryKey: [QUERY_KEYS.dashboards, dashboardId],
     queryFn: () => getDashboards({ id: dashboardId }),
@@ -243,7 +244,8 @@ function dashboard({ dashboardId }: { dashboardId: string }) {
       folder={folderName}
       Owner={folderOwner}
       id={dashboardId}
-      pageId={dashboardId}>
+      pageId={dashboardId}
+      isEditButtonActive={isEditButtonActive}>
       <div className={S.mainContainer}>
         {fullData &&
           fullData?.map((column: ColumnType) => {


### PR DESCRIPTION
## 📖 작업 내용

- [x] 대시보드 수정 페이지에서 헤더 컴포넌트 내부의 관리 버튼 제거

