### PR TITLE
[#189] 대시보드 수정 페이지에서 헤더 내부의 초대하기 버튼과 멤버 컬러칩의 위치를 변경

### DIFF
--- a/src/components/header/dashboardHeader/dashboardHeader.module.css
+++ b/src/components/header/dashboardHeader/dashboardHeader.module.css
@@ -28,10 +28,14 @@
 
 .vectorImage {
   margin-right: 12px;
-  margin-left: 16px;
+  margin-left: 0;
+
+  @media all and (tablet) {
+    margin-left: 12px;
+  }
 
   @media all and (mobile) {
-    margin-left: 0px;
+    margin-left: 24px;
   }
 }
 

--- a/src/components/header/dashboardHeader/dashboardHeader.tsx
+++ b/src/components/header/dashboardHeader/dashboardHeader.tsx
@@ -53,6 +53,7 @@ function DashboardHeader({
             height={16}></Image>
         )}
       </p>
+      {member && <UsersImage member={member} />}
       <div className={S.buttonContainer}>
         {Owner && active && (
           <>
@@ -83,7 +84,6 @@ function DashboardHeader({
           </>
         )}
       </div>
-      {member && <UsersImage member={member} />}
       {active && (
         <Image className={S.vectorImage} src={VectorImg} alt="구분이미지" />
       )}


### PR DESCRIPTION
## 📖 작업 내용

- [x] 대시보드 수정 페이지에서 헤더 내부의 초대하기 버튼과 멤버 컬러칩의 위치를 변경

## 📸 스크린샷
![image](https://github.com/Team-Plants/PLANTS/assets/127609484/51d325c9-ac67-484e-8f2c-eff4118b4597)
