### PR TITLE
[#195] fix : debouncedSearchValue존재에 따라 cursorId & value기준을 재설정

### DIFF
--- a/src/components/table/invitedDashboard/invitedList.tsx
+++ b/src/components/table/invitedDashboard/invitedList.tsx
@@ -20,9 +20,6 @@ function InvitedList() {
   const [target, setTarget] = useState<HTMLDivElement | null>(null);
   const [invitation, setInvitation] = useState<InvitationData[]>();
   const [cursorId, setCursorId] = useState();
-  console.log(cursorId);
-  console.log(debouncedSearchValue);
-
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
     queryKey: ['invitations', debouncedSearchValue],
     queryFn: ({ pageParam: cursorId }) =>

--- a/src/components/table/invitedDashboard/invitedList.tsx
+++ b/src/components/table/invitedDashboard/invitedList.tsx
@@ -20,14 +20,16 @@ function InvitedList() {
   const [target, setTarget] = useState<HTMLDivElement | null>(null);
   const [invitation, setInvitation] = useState<InvitationData[]>();
   const [cursorId, setCursorId] = useState();
+  console.log(cursorId);
+  console.log(debouncedSearchValue);
 
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
     queryKey: ['invitations', debouncedSearchValue],
     queryFn: ({ pageParam: cursorId }) =>
       getInvitations(
         6,
-        cursorId,
-        debouncedSearchValue === '' ? null : debouncedSearchValue,
+        debouncedSearchValue?.length ? undefined : cursorId,
+        debouncedSearchValue?.length ? debouncedSearchValue : null,
       ),
     enabled: true,
     getNextPageParam: (lastPage) => {


### PR DESCRIPTION
## 📖 작업 내용

-[x] debouncedSearchValue존재에 따라 cursorId & value기준을 재설정

## ✅ PR 포인트
- useInfiniteQuery 이해하기

## 📸 스크린샷
#### 수정 전
https://github.com/Team-Plants/PLANTS/assets/138510303/0c685f95-bec6-425f-bcf9-90b0ed97a25c

#### 수정 후
https://github.com/Team-Plants/PLANTS/assets/138510303/a5bb5973-ea03-4095-bb47-35cde844723b


