### PR TITLE
[#196] fix : 거절 & 수락 시 무한스크롤 마지막 cursorId유지 수정

### DIFF
--- a/src/components/table/invitedDashboard/invitedList.tsx
+++ b/src/components/table/invitedDashboard/invitedList.tsx
@@ -26,10 +26,11 @@ function InvitedList() {
     queryFn: ({ pageParam: cursorId }) =>
       getInvitations(
         6,
-        cursorId,
-        debouncedSearchValue === '' ? null : debouncedSearchValue,
+        debouncedSearchValue?.length ? undefined : cursorId,
+        debouncedSearchValue?.length ? debouncedSearchValue : null,
       ),
     enabled: true,
+    gcTime: 5000,
     getNextPageParam: (lastPage) => {
       if (lastPage) {
         return lastPage.cursorId;

--- a/src/components/table/invitedDashboard/invitedList.tsx
+++ b/src/components/table/invitedDashboard/invitedList.tsx
@@ -38,7 +38,7 @@ function InvitedList() {
         return null;
       }
     },
-    initialPageParam: cursorId,
+    initialPageParam: undefined,
   });
 
   useIntersectionObserver({


### PR DESCRIPTION
## 📖 작업 내용

- [x] 거절 수락 버튼 클릭 시, 받아오는 데이터 오류 수정

## ✅ PR 포인트
- [x] useInfiniteQuery initailPageParam : cursorId -> undefined로 수정

## 📸 스크린샷
##### 수정 전

https://github.com/Team-Plants/PLANTS/assets/138510303/7b34cede-b50c-4f7a-94ca-0095a16d0837

##### 수정 후

https://github.com/Team-Plants/PLANTS/assets/138510303/cde66b16-19ea-4456-87ac-3c79183d035d


