### PR TITLE
[#199] refactor : 할일 생성 매니저 드롭다운 외부 클릭시 닫힘 & 태그 css 적용안됨 수정

### DIFF
--- a/src/components/modal/input/selectInput/selectInput.tsx
+++ b/src/components/modal/input/selectInput/selectInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { MutableRefObject, useEffect, useRef, useState } from 'react';
 import S from '@/components/modal/input/selectInput/selectInput.module.css';
 import CheckImg from '@/assets/icons/CheckG.svg';
 import Image from 'next/image';
@@ -7,6 +7,7 @@ import { FieldValues, UseFormSetValue } from 'react-hook-form';
 import ProgressChip from '@/components/chip/progress/progressChip';
 import { StatusType } from '@/components/modal/editTodoModal/editTodoModal';
 import { Option } from '@/components/modal/addTodoModal/addTodoModal';
+import useShowDropDown from '@/hooks/useShowDropDown';
 
 interface SelectInputProps {
   optionData?: Option[];
@@ -26,7 +27,9 @@ function SelectInput({
 }: SelectInputProps) {
   const [selected, setSelected] = useState(placeholder);
   const [selectedImg, setSelectedImg] = useState('');
-  const [showOptions, setShowOptions] = useState(false);
+
+  const ref = useRef() as MutableRefObject<HTMLDivElement>;
+  const [showOptions, setShowOptions] = useShowDropDown(ref, false);
 
   const onChangeSelect = (e: Option) => {
     if (e) {
@@ -39,7 +42,8 @@ function SelectInput({
   return (
     <div
       className={S.selectContainer}
-      onClick={() => setShowOptions((prev) => !prev)}>
+      ref={ref}
+      onClick={() => setShowOptions(!showOptions)}>
       <label className={S.selectedLabel}>
         {selected !== placeholder ? (
           type === 'manager' ? (

--- a/src/components/modal/input/tagInput/tagInput.module.css
+++ b/src/components/modal/input/tagInput/tagInput.module.css
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  height: 48px;
+  overflow: scroll;
   padding: 14px 16px;
   border: 1px solid var(--gray-30);
   border-radius: 6px;
@@ -23,6 +23,7 @@
   display: flex;
   gap: 8px;
   margin-right: 8px;
+  flex-wrap: wrap;
 
   @media all and (mobile) {
     gap: 6px;

--- a/src/components/modal/input/tagInput/tagInput.module.css
+++ b/src/components/modal/input/tagInput/tagInput.module.css
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  overflow: scroll;
+  overflow: auto;
   padding: 14px 16px;
   border: 1px solid var(--gray-30);
   border-radius: 6px;

--- a/src/components/modal/input/tagInput/tagInput.tsx
+++ b/src/components/modal/input/tagInput/tagInput.tsx
@@ -62,7 +62,7 @@ function TagInput({ control, name, setValue }: TagInputProps) {
             <CategoryChip
               content={tagItem.content}
               key={index}
-              color={selectChipColor((tagItem.content.length + index) % 6)}
+              color={selectChipColor((tagItem.content.length + index) % 5)}
             />
           );
         })}

--- a/src/hooks/useShowDropDown.ts
+++ b/src/hooks/useShowDropDown.ts
@@ -1,0 +1,34 @@
+import {
+  MutableRefObject,
+  useState,
+  useEffect,
+  BaseSyntheticEvent,
+  Dispatch,
+  SetStateAction,
+} from 'react';
+
+function useShowDropDown(
+  ref: MutableRefObject<HTMLDivElement | null>,
+  initialBoolean: boolean,
+): [boolean, Dispatch<SetStateAction<boolean>>] {
+  const [showOptions, setShowOptions] = useState<boolean>(initialBoolean);
+
+  useEffect(() => {
+    const onClick = (e: BaseSyntheticEvent | MouseEvent) => {
+      if (ref.current !== null && !ref.current.contains(e.target)) {
+        setShowOptions(!showOptions);
+      }
+    };
+
+    if (showOptions) {
+      window.addEventListener('click', onClick);
+    }
+
+    return () => {
+      window.removeEventListener('click', onClick);
+    };
+  }, [showOptions, ref]);
+  return [showOptions, setShowOptions];
+}
+
+export default useShowDropDown;


### PR DESCRIPTION
## 📖 작업 내용
- 할일 수정 담당자 드롭다운 외부클릭에도 드롭다운 닫히도록 변경했어요.
- 태그 input 색상 설정이 5가지라서 %6 -> %5로 바꿔서 간간히 색상이 적용안되는걸 수정했어요.

## ✅ PR 포인트
- [x] 드롭다운 외부 클릭시에도 잘 닫히는지 확인
- [x] 태그 item 전체를 감싸는 container css에도 flew-wrap을 설정해서 줄바꿈이 되도록 설정했어요
- [x] 색상이 적용안되는 오류가 있느지 확인  

## 📸 스크린샷
##### 수정 전
- 드롭다운 안 닫힘

https://github.com/Team-Plants/PLANTS/assets/138510303/636b3271-d12b-421c-9a6e-1b6c15ed15b1



- 태그 색상 적용 안됨
<img width="539" alt="스크린샷 2024-01-12 오전 12 40 37" src="https://github.com/Team-Plants/PLANTS/assets/138510303/f67eec5f-f99e-4c85-bc3f-9f3fb945be3a">


##### 수정 후

https://github.com/Team-Plants/PLANTS/assets/138510303/68c50c3e-175d-40cd-9998-3f8f52d768de

<img width="365" alt="스크린샷 2024-01-12 오후 4 29 56" src="https://github.com/Team-Plants/PLANTS/assets/138510303/e1615bc3-a69f-46fa-b1d6-6c592ab82354">


